### PR TITLE
Reverting to solidity compiler ^0.5.0 for ConsenSys grading script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 
 before_script:
   - npm install -g ganache-cli
-  - npm install -g truffle
+  - npm install -g truffle@5.0.0
 
 script:
   - git clone https://gist.github.com/7d59ba6ebe581c1ffcc981469e226c6e.git

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0 <0.7.0;
+pragma solidity ^0.5.0;
 
 contract Migrations {
   address public owner;

--- a/contracts/SupplyChain.sol
+++ b/contracts/SupplyChain.sol
@@ -5,7 +5,7 @@
     https://solidity.readthedocs.io/en/v0.5.0/050-breaking-changes.html
 */
 
-pragma solidity >=0.6.0 <0.7.0;
+pragma solidity ^0.5.0;
 
 contract SupplyChain {
 

--- a/test/TestSupplyChain.sol
+++ b/test/TestSupplyChain.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0 <0.7.0;
+pragma solidity ^0.5.0;
 
 import "truffle/Assert.sol";
 import "truffle/DeployedAddresses.sol";

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 module.exports = {
-   compilers: {
-       solc: {
-	   version: '0.6.12'
-       }
-   },  
+//   compilers: {
+//       solc: '0.5.16'
+//   },
   networks: {
     development: {
       host: "localhost",


### PR DESCRIPTION
Per ConsenSys staff, they depend on v 0.5.x solidity compilers for automated grading scripts, thus rolling back the compiler changes from Compiler-and-License branch.